### PR TITLE
Add ability to use "private_key_jwt" for client authentication

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,6 +69,26 @@ For example, an Azure AD OP would be::
 You may now test the authentication by going to (on the development server) http://localhost:8000/openid/login or to any
 of your views that requires authentication.
 
+Using a private key jwt for client authentication
+-------------------------------------------------
+If you are using private keys for client authentication with the OP, you can specify it like::
+
+    OIDC_PROVIDERS = {
+        "mitreid": {
+            "srv_discovery_url": "https://mitreid.org/",
+            "behaviour": OIDC_DEFAULT_BEHAVIOUR,
+            "client_registration": {
+                "client_id": "your_client_id",
+                "redirect_uris": ["http://localhost:8000/openid/callback/login/"],
+                'token_endpoint_auth_method': ['private_key_jwt'],
+                "enc_kid": "rsa_test",
+                "keyset_jwk_file": "file://keys/keyset.jwk"
+            }
+        }
+    }
+
+In this case keys/keyset.jwk is the full keyset (public and private keys) used when registering the client with the OP
+manually. (I.E. you've provided the OP with the public key.)
 
 Features
 --------

--- a/djangooidc/oidc.py
+++ b/djangooidc/oidc.py
@@ -219,10 +219,14 @@ class OIDCClients(object):
         except:
             verify_ssl = True
 
-        if "keyset_jwk_file" in _key_set:
-            print("Found keyset_jwk_file")
-            key_bundle = keyio.keybundle_from_local_file(kwargs["keyset_jwk_file"])
-            args["keyjar"] =keyio.KeyJar(verify_ssl=verify_ssl,key_bundle=key_bundle)
+        # Check to see if there is a keyset specified in the client_registration (if it is a client_registration type)
+        #   This gets used if the authentication method is "private_key_jwt
+        if "client_registration" in _key_set:
+            if "keyset_jwk_file" in kwargs["client_registration"].keys():
+                key_bundle = keyio.keybundle_from_local_file(kwargs["client_registration"]["keyset_jwk_file"],"jwk","sig")
+                key_jar =keyio.KeyJar(verify_ssl=verify_ssl)
+                key_jar.add_kb("",key_bundle)
+                args["keyjar"] = key_jar
 
         client = self.client_cls(client_authn_method=CLIENT_AUTHN_METHOD,
                                  behaviour=kwargs["behaviour"], verify_ssl=verify_ssl, **args)

--- a/djangooidc/oidc.py
+++ b/djangooidc/oidc.py
@@ -15,6 +15,7 @@ from oic.oauth2 import ErrorResponse, MissingEndpoint, ResponseError
 from oic.oic import (AuthorizationRequest, AuthorizationResponse,
                      ProviderConfigurationResponse, RegistrationResponse)
 from oic.utils.authn.client import CLIENT_AUTHN_METHOD
+from oic.utils import keyio
 
 from . import exceptions
 
@@ -217,6 +218,11 @@ class OIDCClients(object):
             verify_ssl = default_ssl_check
         except:
             verify_ssl = True
+
+        if "keyset_jwk_file" in _key_set:
+            print("Found keyset_jwk_file")
+            key_bundle = keyio.keybundle_from_local_file(kwargs["keyset_jwk_file"])
+            args["keyjar"] =keyio.KeyJar(verify_ssl=verify_ssl,key_bundle=key_bundle)
 
         client = self.client_cls(client_authn_method=CLIENT_AUTHN_METHOD,
                                  behaviour=kwargs["behaviour"], verify_ssl=verify_ssl, **args)


### PR DESCRIPTION
This is a bare bones addition to allow the use of `private_key_jwt` client authentication. It will only read a keyset file in the "jwk" format. I believe this will only work for pre-registered clients.