### PR TITLE
Fight Entropy!

### DIFF
--- a/django_rp/settings.py
+++ b/django_rp/settings.py
@@ -1,5 +1,6 @@
 # Django settings for access_web project.
 import os
+import django
 
 DEBUG = True
 TEMPLATE_DEBUG = DEBUG
@@ -95,13 +96,25 @@ TEMPLATE_LOADERS = (
     'django.template.loaders.app_directories.Loader',
 )
 
-MIDDLEWARE_CLASSES = (
-    'django.middleware.common.CommonMiddleware',
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
-)
+if django.VERSION >= (2, 1):
+    MIDDLEWARE = [
+        'django.middleware.security.SecurityMiddleware',
+        'django.contrib.sessions.middleware.SessionMiddleware',
+        'django.middleware.common.CommonMiddleware',
+        'django.middleware.csrf.CsrfViewMiddleware',
+        'django.contrib.auth.middleware.AuthenticationMiddleware',
+        'django.contrib.messages.middleware.MessageMiddleware',
+        'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    ]
+else:
+    MIDDLEWARE_CLASSES = (
+        'django.middleware.common.CommonMiddleware',
+        'django.contrib.sessions.middleware.SessionMiddleware',
+        'django.middleware.csrf.CsrfViewMiddleware',
+        'django.contrib.auth.middleware.AuthenticationMiddleware',
+        'django.contrib.messages.middleware.MessageMiddleware',
+    )
+
 
 SESSION_ENGINE = 'django.contrib.sessions.backends.db'
 
@@ -121,9 +134,28 @@ LOGIN_URL = 'openid'
 
 ROOT_URLCONF = 'django_rp.urls'
 
-TEMPLATE_DIRS = (
-    # os.path.join(BASE_DIR, "django_rp/templates"),
-)
+if django.VERSION >= (2, 1):
+    TEMPLATES = [
+        {
+            'BACKEND': 'django.template.backends.django.DjangoTemplates',
+            'DIRS': [
+                os.path.join(BASE_DIR, 'djangooidc/templates'),
+            ],
+            'APP_DIRS': True,
+            'OPTIONS': {
+                'context_processors': [
+                    'django.template.context_processors.debug',
+                    'django.template.context_processors.request',
+                    'django.contrib.auth.context_processors.auth',
+                    'django.contrib.messages.context_processors.messages',
+                ],
+            },
+        },
+    ]
+else:
+    TEMPLATE_DIRS = (
+        # os.path.join(BASE_DIR, "django_rp/templates"),
+    )
 
 INSTALLED_APPS = (
     'django.contrib.auth',

--- a/djangooidc/__init__.py
+++ b/djangooidc/__init__.py
@@ -1,3 +1,3 @@
 # coding: utf-8
 
-__version__ = '0.0.8'
+__version__ = '0.0.9'

--- a/djangooidc/backends.py
+++ b/djangooidc/backends.py
@@ -16,7 +16,7 @@ class OpenIdConnectBackend(ModelBackend):
     In all other cases, None is returned.
     """
 
-    def authenticate(self, **kwargs):
+    def authenticate(self, request, **kwargs):
         user = None
         if not kwargs or 'sub' not in kwargs.keys():
             return user
@@ -55,7 +55,10 @@ class OpenIdConnectBackend(ModelBackend):
             try:
                 user = UserModel.objects.get_by_natural_key(username)
             except UserModel.DoesNotExist:
-                return None
+                try:
+                    user = UserModel.objects.get(email=kwargs['email'])
+                except UserModel.DoesNotExist:
+                    return None
         return user
 
     def clean_username(self, username):
@@ -73,4 +76,5 @@ class OpenIdConnectBackend(ModelBackend):
 
         By default, returns the user unmodified.
         """
+        user.set_unusable_password()
         return user

--- a/djangooidc/oidc.py
+++ b/djangooidc/oidc.py
@@ -13,7 +13,8 @@ from oic import oic, rndstr
 from oic.exception import MissingAttribute
 from oic.oauth2 import ErrorResponse, MissingEndpoint, ResponseError
 from oic.oic import (AuthorizationRequest, AuthorizationResponse,
-                     ProviderConfigurationResponse, RegistrationResponse)
+                     RegistrationResponse)
+from oic.oic.message import ProviderConfigurationResponse
 from oic.utils.authn.client import CLIENT_AUTHN_METHOD
 from oic.utils import keyio
 

--- a/djangooidc/oidc.py
+++ b/djangooidc/oidc.py
@@ -36,8 +36,7 @@ class Client(oic.Client):
     def __init__(self, client_id=None, ca_certs=None,
                  client_prefs=None, client_authn_method=None, keyjar=None,
                  verify_ssl=True, behaviour=None):
-        oic.Client.__init__(self, client_id, ca_certs, client_prefs,
-                            client_authn_method, keyjar, verify_ssl)
+        oic.Client.__init__(self, client_id=client_id, client_authn_method=client_authn_method, keyjar=keyjar, verify_ssl=verify_ssl, config=client_prefs)
         if behaviour:
             self.behaviour = behaviour
         else:

--- a/djangooidc/oidc.py
+++ b/djangooidc/oidc.py
@@ -44,8 +44,8 @@ class Client(oic.Client):
 
     def create_authn_request(self, session,  # *, - let's not use this fancy py3 thing for compatibility
                              acr_value=None, extra_args=None):
-        session["state"] = rndstr()
-        session["nonce"] = rndstr()
+        session["state"] = rndstr(size=32)
+        session["nonce"] = rndstr(size=32)
         request_args = {
             "response_type": self.behaviour["response_type"],
             "scope": self.behaviour["scope"],

--- a/djangooidc/views.py
+++ b/djangooidc/views.py
@@ -13,8 +13,8 @@ from django.conf import settings
 from django.contrib.auth import logout as auth_logout
 from django.contrib.auth import authenticate, login
 from django.contrib.auth.forms import AuthenticationForm
-from django.contrib.auth.views import login as auth_login_view
-from django.contrib.auth.views import logout as auth_logout_view
+from django.contrib.auth import login as auth_login_view
+from django.contrib.auth import logout as auth_logout_view
 from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import redirect, render_to_response, resolve_url
 from djangooidc.oidc import OIDCClients, OIDCError

--- a/djangooidc/views.py
+++ b/djangooidc/views.py
@@ -89,7 +89,10 @@ def openid(request, op_name=None):
     # authentication request
     if client:
         try:
-            return client.create_authn_request(request.session)
+            acrvalue = None
+            if 'acr_value' in settings.OIDC_PROVIDERS[op_name]['client_registration']:
+                acrvalue = settings.OIDC_PROVIDERS[op_name]['client_registration']['acr_value']
+            return client.create_authn_request(request.session, acr_value=acrvalue)
         except Exception as e:
             return view_error_handler(request, {"error": e})
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ deps =
     django110: django>=1.10,<1.11
     django120: django>=1.11,<1.12
     django22: django>=2.2
+    coverage
     mock
 
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 
 envlist=
-    py{27,35,36}-django{110,120}
+    py{27,37}-django{110,120}
+    py{37}-django{22}
 
 
 [testenv]
@@ -9,7 +10,7 @@ envlist=
 deps =
     django110: django>=1.10,<1.11
     django120: django>=1.11,<1.12
-    coverage
+    django22: django>=2.2
     mock
 
 commands =


### PR DESCRIPTION
* Get tests working with django 2.2.
* Adjust how oic code is called/imported to reflect changes that have happened to the library over time.
* Add `acr_value` support.
* Increase size of some strings to ensure that more modern IDPs don't reject nonces and so on for being too small.
* Bump version.