### PR TITLE
Add Django 3.0 support

### DIFF
--- a/django_rp/settings.py
+++ b/django_rp/settings.py
@@ -37,7 +37,7 @@ TIME_ZONE = 'Europe/Paris'
 
 # Language code for this installation. All choices can be found here:
 # http://www.i18nguy.com/unicode/language-identifiers.html
-LANGUAGE_CODE = 'en-US'
+LANGUAGE_CODE = 'en-us'
 
 SITE_ID = 1
 

--- a/djangooidc/views.py
+++ b/djangooidc/views.py
@@ -16,7 +16,7 @@ from django.contrib.auth.forms import AuthenticationForm
 from django.contrib.auth import login as auth_login_view
 from django.contrib.auth import logout as auth_logout_view
 from django.http import Http404, HttpResponseRedirect
-from django.shortcuts import redirect, render_to_response, resolve_url
+from django.shortcuts import redirect, render, resolve_url
 from djangooidc.oidc import OIDCClients, OIDCError
 
 from . import exceptions
@@ -27,7 +27,7 @@ CLIENTS = OIDCClients(settings)
 
 
 def template_view_error(request, ctx, **kwargs):
-    return render_to_response("djangooidc/error.html", ctx)
+    return render(request, "djangooidc/error.html", ctx)
 
 
 view_error_handler = template_view_error
@@ -97,9 +97,9 @@ def openid(request, op_name=None):
             return view_error_handler(request, {"error": e})
 
     # Otherwise just render the list+form.
-    return render_to_response(template_name,
-                              {"op_list": [i for i in settings.OIDC_PROVIDERS.keys() if i], 'dynamic': dyn,
-                               'form': form, 'ilform': ilform, "next": request.session["next"]})
+    return render(request, template_name,
+                  {"op_list": [i for i in settings.OIDC_PROVIDERS.keys() if i], 'dynamic': dyn,
+                   'form': form, 'ilform': ilform, "next": request.session["next"]})
 
 
 # Step 4: analyze the token returned by the OP

--- a/djangooidc/views.py
+++ b/djangooidc/views.py
@@ -131,7 +131,7 @@ def authz_cb(request):
                 'this login is not valid in this application')
     except OIDCError as e:
         logging.getLogger('djangooidc.views.authz_cb').exception('Problem logging user in')
-        # return render_to_response("djangooidc/error.html", {"error": e, "callback": query})
+        # return render(request, "djangooidc/error.html", {"error": e, "callback": query})
         return view_error_handler(request, {"error": e, "callback": query})
 
 

--- a/testapp/views.py
+++ b/testapp/views.py
@@ -1,11 +1,11 @@
 from django.contrib.auth.decorators import login_required
-from django.shortcuts import render_to_response
+from django.shortcuts import render
 
 
 @login_required
 def home(request):
     # Old: opresult.mako
-    return render_to_response("testapp/result.html", {"userinfo": request.session['userinfo'] if 'userinfo' in request.session.keys() else None})
+    return render(request, "testapp/result.html", {"userinfo": request.session['userinfo'] if 'userinfo' in request.session.keys() else None})
 
 def unprotected(request):
-    return render_to_response("testapp/unprotected.html")
+    return render(request, "testapp/unprotected.html")

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@
 envlist=
     py{27,37}-django{110,120}
     py{37}-django{22}
+    py{37,38}-django{30}
 
 
 [testenv]
@@ -10,7 +11,8 @@ envlist=
 deps =
     django110: django>=1.10,<1.11
     django120: django>=1.11,<1.12
-    django22: django>=2.2
+    django22: django>=2.2,<3.0
+    django30: django>=3.0,<3.1
     coverage
     mock
 


### PR DESCRIPTION
This PR fixes a few problems when running under Django 3.0.  Specifically:

- `django.shortcuts.render_to_response()` [has been removed](https://docs.djangoproject.com/en/3.0/releases/3.0/#features-removed-in-3-0).  It's been [replaced](https://docs.djangoproject.com/en/3.0/releases/2.0/#id1) by `django.shortcuts.render()` which looks to be backwards-compatible to at least the `'django>=1.10'` the project supports.

- When running tox, I also saw a [translation.E004](https://docs.djangoproject.com/en/3.0/ref/checks/#translation) error: `You have provided a value for the LANGUAGE_CODE setting that is not in the LANGUAGES setting.`  It appears that `en-US` should now be `en-us` (which appears to be the default in Django's `global_settings.py` going back a while too).
